### PR TITLE
Add additional functionality - Lock paginator to specific user, refresh timeout after action on widget, add go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,105 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+### macOS template
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Go template
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### VisualStudioCode template
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/
+
+### Linux template
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Necroforger/dgwidgets
+
+go 1.15
+
+require github.com/bwmarrin/discordgo v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/bwmarrin/discordgo v0.22.0 h1:uBxY1HmlVCsW1IuaPjpCGT6A2DBwRn0nvOguQIxDdFM=
+github.com/bwmarrin/discordgo v0.22.0/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
+github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
+github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16 h1:y6ce7gCWtnH+m3dCjzQ1PCuwl28DDIc3VNnvY29DlIA=
+golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/paginator.go
+++ b/paginator.go
@@ -1,6 +1,7 @@
 package dgwidgets
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -25,7 +26,7 @@ type Paginator struct {
 	DeleteReactionsWhenDone bool
 	ColourWhenDone          int
 
-	LockToUser bool
+	lockToUser bool
 	CallerID   string
 
 	running bool
@@ -34,11 +35,10 @@ type Paginator struct {
 // NewPaginator returns a new Paginator
 //    ses      : discordgo session
 //    channelID: channelID to spawn the paginator on
-func NewPaginator(ses *discordgo.Session, channelID, userID string) *Paginator {
+func NewPaginator(ses *discordgo.Session, channelID string) *Paginator {
 	p := &Paginator{
 		Ses:            ses,
 		Pages:          []*discordgo.MessageEmbed{},
-		CallerID:       userID,
 		ColourWhenDone: -1,
 		Widget:         NewWidget(ses, channelID, nil),
 	}
@@ -108,7 +108,7 @@ func (p *Paginator) Spawn() error {
 		}
 	}()
 
-	if p.LockToUser {
+	if p.lockToUser {
 		p.Widget.UserWhitelist = append(p.Widget.UserWhitelist, p.CallerID)
 	}
 
@@ -222,4 +222,13 @@ func (p *Paginator) SetPageFooters() {
 			Text: fmt.Sprintf("#[%d / %d]", index+1, len(p.Pages)),
 		}
 	}
+}
+
+func (p *Paginator) LockToUser(userID string) error {
+	if userID == "" {
+		return errors.New("userID can't be empty")
+	}
+	p.lockToUser = true
+	p.CallerID = userID
+	return nil
 }

--- a/paginator.go
+++ b/paginator.go
@@ -25,7 +25,7 @@ type Paginator struct {
 	DeleteReactionsWhenDone bool
 	ColourWhenDone          int
 
-	lockToUser bool
+	LockToUser bool
 
 	running bool
 }
@@ -35,12 +35,13 @@ type Paginator struct {
 //    channelID: channelID to spawn the paginator on
 func NewPaginator(ses *discordgo.Session, channelID string) *Paginator {
 	p := &Paginator{
-		Ses:   ses,
-		Pages: []*discordgo.MessageEmbed{},
-		Index: 0,
-		Loop:  false,
+		Ses:                     ses,
+		Pages:                   []*discordgo.MessageEmbed{},
+		Index:                   0,
+		Loop:                    false,
 		DeleteMessageWhenDone:   false,
 		DeleteReactionsWhenDone: false,
+		LockToUser:              true,
 		ColourWhenDone:          -1,
 		Widget:                  NewWidget(ses, channelID, nil),
 	}
@@ -192,7 +193,9 @@ func (p *Paginator) Update() error {
 	if p.Widget.Message == nil {
 		return ErrNilMessage
 	}
-
+	if p.Widget.RefreshAfterAction && p.Widget.ticker != nil {
+		_ = p.Widget.RefreshTimeout() // ignore error because ticker will always be present
+	}
 	page, err := p.Page()
 	if err != nil {
 		return err

--- a/paginator.go
+++ b/paginator.go
@@ -1,7 +1,6 @@
 package dgwidgets
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -25,9 +24,6 @@ type Paginator struct {
 	DeleteMessageWhenDone   bool
 	DeleteReactionsWhenDone bool
 	ColourWhenDone          int
-
-	lockToUser bool
-	CallerID   string
 
 	running bool
 }
@@ -107,10 +103,6 @@ func (p *Paginator) Spawn() error {
 			p.Ses.MessageReactionsRemoveAll(p.Widget.ChannelID, p.Widget.Message.ID)
 		}
 	}()
-
-	if p.lockToUser {
-		p.Widget.UserWhitelist = append(p.Widget.UserWhitelist, p.CallerID)
-	}
 
 	page, err := p.Page()
 	if err != nil {
@@ -222,13 +214,4 @@ func (p *Paginator) SetPageFooters() {
 			Text: fmt.Sprintf("#[%d / %d]", index+1, len(p.Pages)),
 		}
 	}
-}
-
-func (p *Paginator) LockToUser(userID string) error {
-	if userID == "" {
-		return errors.New("userID can't be empty")
-	}
-	p.lockToUser = true
-	p.CallerID = userID
-	return nil
 }

--- a/util.go
+++ b/util.go
@@ -24,17 +24,17 @@ func nextMessageReactionAddC(s *discordgo.Session) chan *discordgo.MessageReacti
 
 // EmbedsFromString splits a string into a slice of MessageEmbeds.
 //     txt     : text to split
-//     chunklen: How long the text in each embed should be
+//     chunkLen: How long the text in each embed should be
 //               (if set to 0 or less, it defaults to 2048)
-func EmbedsFromString(txt string, chunklen int) []*discordgo.MessageEmbed {
-	if chunklen <= 0 {
-		chunklen = 2048
+func EmbedsFromString(txt string, chunkLen int) []*discordgo.MessageEmbed {
+	if chunkLen <= 0 {
+		chunkLen = 2048
 	}
 
-	embeds := []*discordgo.MessageEmbed{}
-	for i := 0; i < int((float64(len(txt))/float64(chunklen))+0.5); i++ {
-		start := i * chunklen
-		end := start + chunklen
+	var embeds []*discordgo.MessageEmbed
+	for i := 0; i < int((float64(len(txt))/float64(chunkLen))+0.5); i++ {
+		start := i * chunkLen
+		end := start + chunkLen
 		if end > len(txt) {
 			end = len(txt)
 		}

--- a/widget.go
+++ b/widget.go
@@ -244,6 +244,7 @@ func (w *Widget) RefreshTimeout() error {
 	return w.Reset(w.Timeout)
 }
 
+// LockToUsers adds defined userIDs to the UserWhitelist locking the widget to them
 func (w *Widget) LockToUsers(userIDs ...string) error {
 	if len(userIDs) == 0 {
 		return errors.New("userID can't be empty")

--- a/widget.go
+++ b/widget.go
@@ -243,3 +243,11 @@ func (w *Widget) Stop() error {
 func (w *Widget) RefreshTimeout() error {
 	return w.Reset(w.Timeout)
 }
+
+func (w *Widget) LockToUsers(userIDs ...string) error {
+	if len(userIDs) == 0 {
+		return errors.New("userID can't be empty")
+	}
+	w.UserWhitelist = append(w.UserWhitelist, userIDs...)
+	return nil
+}


### PR DESCRIPTION
Hello there!
Great work on that package it really helped me in creating some navigation for my dumb bot! However, I noticed lack of basic settings that prevented me from using this. So I decided to add them.

1. The bot lacks refresh of the timeout. When I was using it on pretty lengthy lists it was terminating the widget after fixed timeout.
2. The paginator was accesible for any user on the channel. There was no functionality of restricting the navigation for specific user, or the caller themself.
3. It's been quite some time. I think it would be good to use Go modules for that project.

**Changes proposed in this PR:**
* Change the timeout handling using `time.Ticker`. Added functionality to reset and stop ticker.
* Add functionality to refresh Timeout ticker after performing action on the widget. Can be enabled/disabled using `RefreshAfterAction` variable.
* Add functionality to explicitly lock paginator only for the caller. This prevents the other users from interacting with paginator. 
* Move project to Go modules.
* Add .gitignore

I will keep the edits on my own fork and once I add something useful, will create another PR.

Cheers!